### PR TITLE
Configure dialyzer and fix multiple warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 /log
 /docs
 /rel/poxa
+.local.plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
 env:
   matrix:
     - POXA_REGISTRY_ADAPTER=gproc
+before_script:
+  - export PLT_FILENAME=elixir-$TRAVIS_ELIXIR_VERSION-$TRAVIS_OTP_RELEASE.plt
+  - wget -O .local.plt https://s3.amazonaws.com/poxa-plt/travis_elixir_plts/$PLT_FILENAME || true
+script:
+  - mix test
+  - mix dialyzer
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/lib/poxa.ex
+++ b/lib/poxa.ex
@@ -63,12 +63,18 @@ defmodule Poxa do
       {:ok, ssl_config} ->
         if Enum.all?([:port, :certfile, :keyfile], &Keyword.has_key?(ssl_config, &1)) do
           ssl_port = Keyword.get(ssl_config, :port)
-          {:ok, _} = :cowboy.start_https(:https, 100, ssl_config, [env: [dispatch: dispatch] ])
           Logger.info "Starting Poxa using SSL on port #{ssl_port}"
+          {:ok, _} = :cowboy.start_https(:https, 100, ssl_config, [env: [dispatch: dispatch] ])
+          :ok
         else
-          Logger.error "Must specify port, certfile and keyfile (cacertfile optional)"
+          msg = "Must specify port, certfile and keyfile (cacertfile optional)"
+          Logger.error msg
+          {:error, msg}
         end
-      :error -> Logger.info "SSL not configured/started"
+      :error ->
+        msg = "SSL not configured/started"
+        Logger.info msg
+        {:error, msg}
     end
   end
 end

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -1,4 +1,6 @@
 defmodule Poxa.Channel do
+  alias Poxa.PresenceSubscription
+
   @moduledoc """
   A module to work with channels
 
@@ -98,13 +100,13 @@ defmodule Poxa.Channel do
   @doc """
   Returns a boolean indicating if the user identified by `identifier` is subscribed to the channel.
   """
-  @spec member?(binary, pid | :_ |  PresenceSubscription.user_id) :: boolean
+  @spec member?(binary, pid | :_ | PresenceSubscription.user_id) :: boolean
   def member?(channel, identifier \\ :_), do: subscription_count(channel, identifier) != 0
 
   @doc """
   Returns how many connections are opened on the `channel`
   """
-  @spec subscription_count(binary, pid | :_) :: non_neg_integer
+  @spec subscription_count(binary, pid | :_ | PresenceSubscription.user_id) :: non_neg_integer
   def subscription_count(channel, pid \\ :_) do
     Poxa.registry.subscription_count(channel, pid)
   end

--- a/lib/poxa/event.ex
+++ b/lib/poxa/event.ex
@@ -8,7 +8,7 @@ defmodule Poxa.Event do
 
   It adds the socket_id if not available
   """
-  @spec notify(atom, Map.t) :: :ok
+  @spec notify(atom, map) :: :ok
   def notify(event, %{socket_id: _socket_id} = data) do
     GenEvent.notify(Poxa.Event, Map.put(data, :event, event))
   end

--- a/lib/poxa/presence_subscription.ex
+++ b/lib/poxa/presence_subscription.ex
@@ -40,6 +40,7 @@ defmodule Poxa.PresenceSubscription do
     %__MODULE__{channel: channel, channel_data: Poxa.registry.unique_subscriptions(channel)}
   end
 
+  @spec extract_userid_and_userinfo(map) :: {user_id, user_info}
   defp extract_userid_and_userinfo(channel_data) do
     user_id = sanitize_user_id(channel_data["user_id"])
     user_info = channel_data["user_info"]

--- a/lib/poxa/registry.ex
+++ b/lib/poxa/registry.ex
@@ -1,35 +1,37 @@
 defmodule Poxa.Registry do
+  alias Poxa.PresenceSubscription
+
   @doc """
   Registers a property for the current process.
   """
-  @callback register!(String.t) :: any
+  @callback register!(binary) :: any
 
   @doc """
   Registers a property for the current process with a given value.
   """
-  @callback register!(String.t, any) :: any
+  @callback register!(binary, any) :: any
 
   @doc """
   Unregisters a property for the current process.
   """
-  @callback unregister!(String.t) :: any
+  @callback unregister!(binary) :: any
 
   @doc """
   Sends a message to a channel and identify it as coming from the given sender.
   """
-  @callback send!(String.t, String.t, PresenceSubscription.user_id | pid) :: any
+  @callback send!(binary, binary, PresenceSubscription.user_id | pid) :: any
 
   @doc """
   Sends a message to a channel and identify it as coming from the given sender
   through a specific socket_id.
   """
-  @callback send!(String.t, String.t, any, String.t) :: any
+  @callback send!(binary, binary, any, binary) :: any
 
   @doc """
   Returns the subscription count of a channel. If a connection identifier is provided,
   it counts only the subscriptions identified by the given identifier.
   """
-  @callback subscription_count(String.t, PresenceSubscription.user_id | pid | :_) :: non_neg_integer
+  @callback subscription_count(binary, PresenceSubscription.user_id | pid | :_) :: non_neg_integer
 
   @doc """
   Returns the presence channel subscriptions of the given process.
@@ -44,12 +46,12 @@ defmodule Poxa.Registry do
   @doc """
   Returns the unique subscriptions of the given channel.
   """
-  @callback unique_subscriptions(String.t) :: list(tuple())
+  @callback unique_subscriptions(binary) :: list(tuple())
 
   @doc """
   Returns the value assigned with the given property.
   """
-  @callback fetch(String.t) :: any
+  @callback fetch(binary) :: any
 
   @doc """
   Cleans up the registry data.

--- a/lib/poxa/socket_id.ex
+++ b/lib/poxa/socket_id.ex
@@ -18,7 +18,7 @@ defmodule Poxa.SocketId do
   iex> Poxa.SocketId.valid? "123.456:channel-private"
   false
   """
-  @spec valid?(String.t) :: boolean
+  @spec valid?(binary) :: boolean
   def valid?(socket_id) do
     Regex.match?(~r/\A\d+\.\d+\z/, socket_id)
   end
@@ -26,7 +26,7 @@ defmodule Poxa.SocketId do
   @doc """
   Register the `socket_id` as a property of the process
   """
-  @spec register!(String.t) :: true
+  @spec register!(binary) :: true
   def register!(socket_id) do
     Poxa.registry.register!(:socket_id, socket_id)
   end
@@ -36,7 +36,7 @@ defmodule Poxa.SocketId do
 
   It throws an ArgumentError if the process has not socket_id
   """
-  @spec mine :: String.t
+  @spec mine :: binary
   def mine do
     Poxa.registry.fetch(:socket_id)
   end

--- a/lib/poxa/web_hook/dispatcher.ex
+++ b/lib/poxa/web_hook/dispatcher.ex
@@ -47,11 +47,11 @@ defmodule Poxa.WebHook.Dispatcher do
   defp pusher_headers(body) do
     {:ok, app_key} = Application.fetch_env(:poxa, :app_key)
     {:ok, app_secret} = Application.fetch_env(:poxa, :app_secret)
-    %{
-      "Content-Type"       => "application/json",
-      "X-Pusher-Key"       => app_key,
-      "X-Pusher-Signature" => CryptoHelper.hmac256_to_string(app_secret, body)
-    }
+    [
+      "Content-Type",       "application/json",
+      "X-Pusher-Key",       app_key,
+      "X-Pusher-Signature", CryptoHelper.hmac256_to_string(app_secret, body),
+    ]
   end
 
   defp time_ms, do: :erlang.system_time(:milli_seconds)

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,13 @@ defmodule Poxa.Mixfile do
       version: "0.6.0",
       name: "Poxa",
       elixir: "~> 1.1",
-      deps: deps ]
+      deps: deps,
+      dialyzer: [
+        plt_add_apps: ~w(cowboy exjsx gproc httpoison signaturex),
+        plt_file: ".local.plt",
+        flags: ~w(-Wunmatched_returns -Werror_handling -Wrace_conditions -Wno_opaque --fullpath --statistics)
+      ]
+    ]
   end
 
   def application do
@@ -27,6 +33,7 @@ defmodule Poxa.Mixfile do
       {:inch_ex, "~> 0.5.1", only: :docs},
       {:httpoison, "~> 0.8"},
       {:ex2ms, "~> 1.4.0"},
-      {:watcher, "~> 1.0.0"} ]
+      {:watcher, "~> 1.0.0"},
+      {:dialyxir, "~> 0.3", only: [:dev, :test]}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "conform": {:hex, :conform, "0.16.0"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
+  "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "edip": {:hex, :edip, "0.4.1"},
   "erlware_commons": {:hex, :erlware_commons, "0.13.0"},
   "ex2ms": {:hex, :ex2ms, "1.4.0"},

--- a/test/web_hook/dispatcher_test.exs
+++ b/test/web_hook/dispatcher_test.exs
@@ -41,11 +41,11 @@ defmodule Poxa.WebHook.DispatcherTest do
         "time_ms" => _,
         "events"  => ~w(event_1 event_2)
       },
-      headers: %{
-        "Content-Type"       => "application/json",
-        "X-Pusher-Key"       => "app_key",
-        "X-Pusher-Signature" => _
-      }
+      headers: [
+        "Content-Type",       "application/json",
+        "X-Pusher-Key",       "app_key",
+        "X-Pusher-Signature", _
+      ]
     }
   end
 end


### PR DESCRIPTION
* This conventions the use of the `binary` type rather than `String.t`
* There is still quite a lot of noise cause by -Wunmatched_returns, but I think
we should keep it. These warnings are annoying when we are just interested on
the side effects of a function call. However, it's important to know when we are
not matching on returns as sometimes we should have done it. I have an idea of
how to integrate these reports into PRs and care just about the new warnings.
* For now, I'm ignoring some warnings related to:
  * guards that actually don't exist on the lines dialyzer points to
  * string interpolation that work fine